### PR TITLE
Remove static `str` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Possible header types:
 
 ## [Unreleased]
 
+## v0.2.2 (2022-02-24)
+
+### Features
+
+* Replace usage of `&'static str` with `&str`
+* Add `from()` constructors for API clients so easier to pass in access tokens if needed.
+* Add new `UrlUploader::url()` fluent method, which can be useful when the
+  `from()` constructor is used.
+
 ## v0.2.1 (2022-02-16)
 
 ### Bug Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-wistia"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Ritvik Nag <rv.kvetch@gmail.com>"]
 description = "A rust crate wrapping Wistia's Data and Upload API into a simple easy to use interface"
 documentation = "https://docs.rs/rust-wistia/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-wistia"
-version = "0.2.2"
+version = "0.2.1"
 authors = ["Ritvik Nag <rv.kvetch@gmail.com>"]
 description = "A rust crate wrapping Wistia's Data and Upload API into a simple easy to use interface"
 documentation = "https://docs.rs/rust-wistia/"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This crate works with Cargo with a `Cargo.toml` like:
 
 ```toml
 [dependencies]
-rust-wistia = "0.2.1"
+rust-wistia = "0.2.2"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -85,7 +85,7 @@ To do this, disable the default "rust-tls" feature and enable the "native-tls" f
 
 ```toml
 [dependencies]
-rust-wistia = { version = "0.2.1", default-features = false, features = ["native-tls", "logging", "serde-std"] }
+rust-wistia = { version = "0.2.2", default-features = false, features = ["native-tls", "logging", "serde-std"] }
 ```
 
 [`hyper`]: https://docs.rs/hyper

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ tokio = { version = "1", features = ["full"] }
 Getting started with the `rust-wistia` library is easy:
 
 1. Set **WISTIA_API_TOKEN** in your environment; you can
-   also use the `from_token` constructor
+   also use the `from` constructor
    to explicitly set the token value.
    Find out more  about [Authentication and Access Tokens](https://wistia.com/support/developers/data-api#creating-and-managing-access-tokens)
    in the Wistia API Documentation.

--- a/src/api/upload/file.rs
+++ b/src/api/upload/file.rs
@@ -54,7 +54,7 @@ where
     /// * `access_token` - An API access token used to make requests to the
     /// Wistia API.
     ///
-    pub fn with_token(file_path: P, access_token: &'static str) -> Self {
+    pub fn with_token(file_path: P, access_token: &str) -> Self {
         Self {
             client: UploadClient::from_token(access_token),
             req: UploadFileRequest::new(file_path),
@@ -81,28 +81,28 @@ where
     /// The hashed id of the project to upload media into. If omitted, a new
     /// project will be created and uploaded to. The naming convention used
     /// for such projects is `Uploads_YYYY-MM-DD`.
-    pub fn project_id(mut self, project_id: &'a str) -> FileUploader<'a, P> {
+    pub fn project_id(mut self, project_id: &'a str) -> Self {
         self.req.project_id = Some(project_id);
         self
     }
 
     /// A display name to use for the media in Wistia. If omitted, the filename
     /// will be used instead. This field is limited to 255 characters.
-    pub fn name(mut self, name: &'a str) -> FileUploader<'a, P> {
+    pub fn name(mut self, name: &'a str) -> Self {
         self.req.name = Some(name);
         self
     }
 
     /// A description to use for the media in Wistia. You can use basic HTML
     /// here, but note that both HTML and CSS will be sanitized.
-    pub fn description(mut self, description: &'a str) -> FileUploader<'a, P> {
+    pub fn description(mut self, description: &'a str) -> Self {
         self.req.description = Some(description);
         self
     }
 
     /// A Wistia contact id, an integer value. If omitted, it will default to
     /// the contact_id of the account’s owner.
-    pub fn contact_id(mut self, contact_id: &'a str) -> FileUploader<'a, P> {
+    pub fn contact_id(mut self, contact_id: &'a str) -> Self {
         self.req.contact_id = Some(contact_id);
         self
     }

--- a/src/api/upload/link.rs
+++ b/src/api/upload/link.rs
@@ -20,6 +20,26 @@ pub struct UrlUploader<'a> {
     req: UploadUrlRequest<'a>,
 }
 
+impl<'a> From<String> for UrlUploader<'a> {
+    /// Create a new `UrlUploader` from an access token
+    fn from(token: String) -> Self {
+        Self {
+            client: UploadClient::from(token),
+            req: UploadUrlRequest::default(),
+        }
+    }
+}
+
+impl<'a> From<&str> for UrlUploader<'a> {
+    /// Create a new `UrlUploader` from an access token
+    fn from(token: &str) -> Self {
+        Self {
+            client: UploadClient::from(token),
+            req: UploadUrlRequest::default(),
+        }
+    }
+}
+
 impl<'a> UrlUploader<'a> {
     /// Create an `UrlUploader` with a new HTTPS client, with the access token
     /// retrieved from the environment.
@@ -49,9 +69,9 @@ impl<'a> UrlUploader<'a> {
     /// * `access_token` - An API access token used to make requests to the
     /// Wistia API.
     ///
-    pub fn with_token(url: &'a str, access_token: &'static str) -> Self {
+    pub fn with_token(url: &'a str, access_token: &str) -> Self {
         Self {
-            client: UploadClient::from_token(access_token),
+            client: UploadClient::from(access_token),
             req: UploadUrlRequest {
                 url,
                 ..Default::default()
@@ -77,31 +97,42 @@ impl<'a> UrlUploader<'a> {
         }
     }
 
+    /// Set the publicly-accessible URL link to the media file. The link
+    /// will be *form-url encoded* into the request body.
+    ///
+    /// # Note
+    /// This method call is only needed when the `UrlUploader::from`
+    /// constructor is called.
+    pub fn url(mut self, url: &'a str) -> Self {
+        self.req.url = url;
+        self
+    }
+
     /// The hashed id of the project to upload media into. If omitted, a new
     /// project will be created and uploaded to. The naming convention used
     /// for such projects is `Uploads_YYYY-MM-DD`.
-    pub fn project_id(mut self, project_id: &'a str) -> UrlUploader<'a> {
+    pub fn project_id(mut self, project_id: &'a str) -> Self {
         self.req.project_id = Some(project_id);
         self
     }
 
     /// A display name to use for the media in Wistia. If omitted, the filename
     /// will be used instead. This field is limited to 255 characters.
-    pub fn name(mut self, name: &'a str) -> UrlUploader<'a> {
+    pub fn name(mut self, name: &'a str) -> Self {
         self.req.name = Some(name);
         self
     }
 
     /// A description to use for the media in Wistia. You can use basic HTML
     /// here, but note that both HTML and CSS will be sanitized.
-    pub fn description(mut self, description: &'a str) -> UrlUploader<'a> {
+    pub fn description(mut self, description: &'a str) -> Self {
         self.req.description = Some(description);
         self
     }
 
     /// A Wistia contact id, an integer value. If omitted, it will default to
     /// the contact_id of the account’s owner.
-    pub fn contact_id(mut self, contact_id: &'a str) -> UrlUploader<'a> {
+    pub fn contact_id(mut self, contact_id: &'a str) -> Self {
         self.req.contact_id = Some(contact_id);
         self
     }


### PR DESCRIPTION
* Remove usage of `&'static str`
* Add `url()` fluent method to `UrlUploader`
* Add `from()` constructors for API clients so easier to pass in access tokens if needed.